### PR TITLE
Make possible to specify the buffer size for the pipes

### DIFF
--- a/lib/win32/pipe/client.rb
+++ b/lib/win32/pipe/client.rb
@@ -27,8 +27,8 @@ module Win32
     #     puts "Got [#{data}] back from pipe server"
     #  end
     #
-    def initialize(name, pipe_mode = DEFAULT_PIPE_MODE, open_mode = DEFAULT_OPEN_MODE)
-      super(name, pipe_mode, open_mode)
+    def initialize(name, pipe_mode = DEFAULT_PIPE_MODE, open_mode = DEFAULT_OPEN_MODE, pipe_buffer_size = DEFAULT_PIPE_BUFFER_SIZE)
+      super(name, pipe_mode, open_mode, pipe_buffer_size)
 
       @pipe = CreateFile(
         @name,

--- a/lib/win32/pipe/server.rb
+++ b/lib/win32/pipe/server.rb
@@ -14,22 +14,22 @@ module Win32
     #--
     # The default pipe_mode also happens to be 0.
     #
-    def initialize(name, pipe_mode = 0, open_mode = Pipe::ACCESS_DUPLEX)
-      super(name, pipe_mode, open_mode)
+    def initialize(name, pipe_mode = 0, open_mode = Pipe::ACCESS_DUPLEX, pipe_buffer_size = DEFAULT_PIPE_BUFFER_SIZE)
+      super(name, pipe_mode, open_mode, pipe_buffer_size)
 
       @pipe = CreateNamedPipe(
         @name,
         @open_mode,
         @pipe_mode,
         PIPE_UNLIMITED_INSTANCES,
-        PIPE_BUFFER_SIZE,
-        PIPE_BUFFER_SIZE,
+        pipe_buffer_size,
+        pipe_buffer_size,
         PIPE_TIMEOUT,
         nil
       )
 
       if @pipe == INVALID_HANDLE_VALUE
-        raise
+        raise SystemCallError.new("CreateNamedPipe", FFI.errno)
       end
 
       if block_given?


### PR DESCRIPTION
- add a new parameter pipe_buffer_size with a default value to both client and server initialize methods. (keep compatibility with existing code)
- perf improvments:
  - avoid using a new buffer for each read/write operation
  - change default buffer size to 4096
